### PR TITLE
update to include Sense 2 build target alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "wipeColor": "#8bc34a",
     "requestedPermissions": [],
     "buildTargets": [
-      "hera"
+      "hera",
+      "rhea"
     ],
     "i18n": {},
     "defaultLanguage": "en-US",


### PR DESCRIPTION
I found that this worked perfectly (after resolving some USB permission issues) for side-loading to a Sense 2 after I added the model alias for it ("rhea").  I think [this commit ](https://github.com/Fitbit/fitbit-sdk-toolchain/pull/311/commits/e09519743fa7296d98ad5deb46f5dd1b8ce68d3b)is where I figured out that Sense 2 is called rhea.